### PR TITLE
feat(terraform): add warehouses, compute pool, image repo, stages, and resource monitor

### DIFF
--- a/terraform/compute_pools.tf
+++ b/terraform/compute_pools.tf
@@ -1,0 +1,20 @@
+# -----------------------------------------------------------------------------
+# Compute Pools — SPCS compute for Payment Authorization Command Center
+# Spec reference: Section 3.9.1
+#
+# Note: Compute pools are NOT a native Terraform resource in
+# snowflakedb/snowflake v2.14. We use snowflake_execute for DDL.
+# -----------------------------------------------------------------------------
+
+resource "snowflake_execute" "payments_dashboard_pool" {
+  execute = <<-EOT
+    CREATE COMPUTE POOL IF NOT EXISTS PAYMENTS_DASHBOARD_POOL
+      MIN_NODES        = 1
+      MAX_NODES        = 2
+      INSTANCE_FAMILY  = CPU_X64_S
+      AUTO_SUSPEND_SECS = 3600
+      COMMENT          = 'SPCS compute pool for Streamlit dashboard container'
+  EOT
+  revert  = "DROP COMPUTE POOL IF EXISTS PAYMENTS_DASHBOARD_POOL"
+  query   = "SHOW COMPUTE POOLS LIKE 'PAYMENTS_DASHBOARD_POOL'"
+}

--- a/terraform/grants.tf
+++ b/terraform/grants.tf
@@ -149,3 +149,86 @@ resource "snowflake_grant_privileges_to_account_role" "ops_schema_serve" {
     schema_name = snowflake_schema.serve.fully_qualified_name
   }
 }
+
+# =============================================================================
+# Warehouse USAGE grants (Issue #2)
+# Spec reference: Section 3.9.6
+#
+# Grant mapping:
+#   PAYMENTS_APP_ROLE     → USAGE on PAYMENTS_INTERACTIVE_WH + PAYMENTS_ADMIN_WH
+#   PAYMENTS_INGEST_ROLE  → no warehouse (HP connector is serverless)
+#   PAYMENTS_OPS_ROLE     → USAGE on PAYMENTS_ADMIN_WH
+#   PAYMENTS_ADMIN_ROLE   → USAGE + OPERATE on all warehouses
+# =============================================================================
+
+# --- PAYMENTS_APP_ROLE warehouse grants ---
+
+resource "snowflake_execute" "app_interactive_wh_usage" {
+  execute = "GRANT USAGE ON WAREHOUSE PAYMENTS_INTERACTIVE_WH TO ROLE ${snowflake_account_role.payments_app.name}"
+  revert  = "REVOKE USAGE ON WAREHOUSE PAYMENTS_INTERACTIVE_WH FROM ROLE ${snowflake_account_role.payments_app.name}"
+
+  depends_on = [snowflake_execute.payments_interactive_wh]
+}
+
+resource "snowflake_grant_privileges_to_account_role" "app_admin_wh_usage" {
+  account_role_name = snowflake_account_role.payments_app.name
+  privileges        = ["USAGE"]
+
+  on_account_object {
+    object_type = "WAREHOUSE"
+    object_name = snowflake_warehouse.payments_admin_wh.name
+  }
+}
+
+# --- PAYMENTS_OPS_ROLE warehouse grants ---
+
+resource "snowflake_grant_privileges_to_account_role" "ops_admin_wh_usage" {
+  account_role_name = snowflake_account_role.payments_ops.name
+  privileges        = ["USAGE"]
+
+  on_account_object {
+    object_type = "WAREHOUSE"
+    object_name = snowflake_warehouse.payments_admin_wh.name
+  }
+}
+
+# --- PAYMENTS_ADMIN_ROLE warehouse grants (all warehouses) ---
+
+resource "snowflake_execute" "admin_interactive_wh_usage" {
+  execute = "GRANT USAGE, OPERATE ON WAREHOUSE PAYMENTS_INTERACTIVE_WH TO ROLE ${snowflake_account_role.payments_admin.name}"
+  revert  = "REVOKE USAGE, OPERATE ON WAREHOUSE PAYMENTS_INTERACTIVE_WH FROM ROLE ${snowflake_account_role.payments_admin.name}"
+
+  depends_on = [snowflake_execute.payments_interactive_wh]
+}
+
+resource "snowflake_grant_privileges_to_account_role" "admin_refresh_wh_usage" {
+  account_role_name = snowflake_account_role.payments_admin.name
+  privileges        = ["USAGE", "OPERATE"]
+
+  on_account_object {
+    object_type = "WAREHOUSE"
+    object_name = snowflake_warehouse.payments_refresh_wh.name
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "admin_admin_wh_usage" {
+  account_role_name = snowflake_account_role.payments_admin.name
+  privileges        = ["USAGE", "OPERATE"]
+
+  on_account_object {
+    object_type = "WAREHOUSE"
+    object_name = snowflake_warehouse.payments_admin_wh.name
+  }
+}
+
+# =============================================================================
+# BIND SERVICE ENDPOINT — required for SPCS service creation
+# Spec reference: Section 3.9.6
+# =============================================================================
+
+resource "snowflake_grant_privileges_to_account_role" "app_bind_service_endpoint" {
+  account_role_name = snowflake_account_role.payments_app.name
+  privileges        = ["BIND SERVICE ENDPOINT"]
+
+  on_account = true
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -26,3 +26,34 @@ output "role_names" {
     ops    = snowflake_account_role.payments_ops.name
   }
 }
+
+# -----------------------------------------------------------------------------
+# Issue #2 outputs — warehouses, compute, stages
+# -----------------------------------------------------------------------------
+
+output "warehouse_names" {
+  description = "Map of warehouse logical names to Snowflake warehouse names"
+  value = {
+    interactive = "PAYMENTS_INTERACTIVE_WH"
+    refresh     = snowflake_warehouse.payments_refresh_wh.name
+    admin       = snowflake_warehouse.payments_admin_wh.name
+  }
+}
+
+output "compute_pool_name" {
+  description = "Name of the SPCS compute pool for the dashboard"
+  value       = "PAYMENTS_DASHBOARD_POOL"
+}
+
+output "stage_names" {
+  description = "Map of stage/repo logical names to Snowflake names"
+  value = {
+    specs_stage    = snowflake_stage_internal.specs.fully_qualified_name
+    image_repo     = "DASHBOARD_REPO"
+  }
+}
+
+output "resource_monitor_name" {
+  description = "Name of the payments resource monitor"
+  value       = snowflake_resource_monitor.payments_monitor.name
+}

--- a/terraform/resource_monitor.tf
+++ b/terraform/resource_monitor.tf
@@ -1,0 +1,21 @@
+# -----------------------------------------------------------------------------
+# Resource Monitor — cost control for Payment Authorization Command Center
+# Spec reference: Section 3.9.6
+#
+# Monitors credit usage across all payment warehouses and triggers
+# notifications/suspensions at defined thresholds.
+#
+# Note: Assigning resource monitors to warehouses requires ACCOUNTADMIN role.
+# -----------------------------------------------------------------------------
+
+resource "snowflake_resource_monitor" "payments_monitor" {
+  name         = "PAYMENTS_MONITOR"
+  credit_quota = 100
+
+  frequency       = "MONTHLY"
+  start_timestamp = "IMMEDIATELY"
+
+  notify_triggers            = [75, 90]
+  suspend_trigger            = 100
+  suspend_immediate_trigger  = 110
+}

--- a/terraform/stages.tf
+++ b/terraform/stages.tf
@@ -1,0 +1,33 @@
+# -----------------------------------------------------------------------------
+# Stages & Image Repository — SPCS artifacts for dashboard deployment
+# Spec reference: Sections 3.9.2, 3.9.6
+#
+# Resources:
+#   DASHBOARD_REPO — image repository in APP schema for container images
+#   SPECS          — internal stage in APP schema for service spec YAML files
+#
+# Note: Image repositories are NOT a native Terraform resource in
+# snowflakedb/snowflake v2.14. We use snowflake_execute for DDL.
+# The internal stage uses the native snowflake_stage resource.
+# -----------------------------------------------------------------------------
+
+# =============================================================================
+# Image Repository — PAYMENTS_DB.APP.DASHBOARD_REPO
+# =============================================================================
+
+resource "snowflake_execute" "dashboard_repo" {
+  execute = "CREATE IMAGE REPOSITORY IF NOT EXISTS \"${snowflake_database.payments_db.name}\".\"${snowflake_schema.app.name}\".\"DASHBOARD_REPO\" COMMENT = 'Container image repository for Streamlit dashboard'"
+  revert  = "DROP IMAGE REPOSITORY IF EXISTS \"${snowflake_database.payments_db.name}\".\"${snowflake_schema.app.name}\".\"DASHBOARD_REPO\""
+  query   = "SHOW IMAGE REPOSITORIES LIKE 'DASHBOARD_REPO' IN SCHEMA \"${snowflake_database.payments_db.name}\".\"${snowflake_schema.app.name}\""
+}
+
+# =============================================================================
+# Spec Stage — PAYMENTS_DB.APP.SPECS
+# =============================================================================
+
+resource "snowflake_stage_internal" "specs" {
+  database = snowflake_database.payments_db.name
+  schema   = snowflake_schema.app.name
+  name     = "SPECS"
+  comment  = "Internal stage for SPCS service specification YAML files"
+}

--- a/terraform/warehouses.tf
+++ b/terraform/warehouses.tf
@@ -1,0 +1,52 @@
+# -----------------------------------------------------------------------------
+# Warehouses — compute resources for Payment Authorization Command Center
+# Spec reference: Sections 3.6, 3.7
+#
+# Three warehouses:
+#   PAYMENTS_INTERACTIVE_WH — interactive type for low-latency queries
+#   PAYMENTS_REFRESH_WH     — standard type for dynamic table refreshes
+#   PAYMENTS_ADMIN_WH       — standard type for admin/ops tasks
+#
+# Note: Interactive warehouses are NOT supported as a native Terraform resource
+# in snowflakedb/snowflake v2.14. The warehouse_type field only accepts
+# STANDARD or SNOWPARK-OPTIMIZED. We use snowflake_execute for the interactive
+# warehouse DDL.
+# -----------------------------------------------------------------------------
+
+# =============================================================================
+# PAYMENTS_INTERACTIVE_WH — Interactive warehouse (via snowflake_execute)
+# =============================================================================
+
+resource "snowflake_execute" "payments_interactive_wh" {
+  execute = "CREATE INTERACTIVE WAREHOUSE IF NOT EXISTS PAYMENTS_INTERACTIVE_WH WAREHOUSE_SIZE = 'XSMALL' AUTO_SUSPEND = 86400 AUTO_RESUME = TRUE INITIALLY_SUSPENDED = TRUE COMMENT = 'Interactive warehouse for low-latency payment queries'"
+  revert  = "DROP WAREHOUSE IF EXISTS PAYMENTS_INTERACTIVE_WH"
+  query   = "SHOW WAREHOUSES LIKE 'PAYMENTS_INTERACTIVE_WH'"
+}
+
+# =============================================================================
+# PAYMENTS_REFRESH_WH — Standard warehouse for dynamic table refreshes
+# =============================================================================
+
+resource "snowflake_warehouse" "payments_refresh_wh" {
+  name                = "PAYMENTS_REFRESH_WH"
+  warehouse_type      = "STANDARD"
+  warehouse_size      = "XSMALL"
+  auto_suspend        = 120
+  auto_resume         = true
+  initially_suspended = true
+  comment             = "Standard warehouse for dynamic table and materialized view refreshes"
+}
+
+# =============================================================================
+# PAYMENTS_ADMIN_WH — Standard warehouse for admin/ops tasks
+# =============================================================================
+
+resource "snowflake_warehouse" "payments_admin_wh" {
+  name                = "PAYMENTS_ADMIN_WH"
+  warehouse_type      = "STANDARD"
+  warehouse_size      = "XSMALL"
+  auto_suspend        = 60
+  auto_resume         = true
+  initially_suspended = true
+  comment             = "Standard warehouse for admin and operational tasks"
+}

--- a/tests/validate_terraform.sh
+++ b/tests/validate_terraform.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 # tests/validate_terraform.sh
-# TDD validation script for Issue #1: Terraform database, schemas, and roles
+# TDD validation script for Payment Authorization Command Center
 #
-# Checks:
-#   1. terraform validate succeeds
-#   2. terraform plan output contains all expected resources
+# Issue #1: database, schemas, roles, grants
+# Issue #2: warehouses, compute pool, image repo, stages, resource monitor
 #
 # Usage: ./tests/validate_terraform.sh
 set -euo pipefail
@@ -30,12 +29,12 @@ else
 fi
 
 # --- Test 2: Expected resource declarations in .tf files ---
-echo "[2] Expected resource declarations"
+echo "[2] Expected resource declarations (Issue #1)"
 
 # Scan all .tf files for resource declarations (no credentials needed)
 ALL_TF_CONTENT=$(cat "$TF_DIR"/*.tf 2>/dev/null || true)
 
-EXPECTED_RESOURCES=(
+EXPECTED_RESOURCES_ISSUE1=(
   'resource "snowflake_database" "payments_db"'
   'resource "snowflake_schema" "raw"'
   'resource "snowflake_schema" "serve"'
@@ -51,7 +50,7 @@ EXPECTED_RESOURCES=(
   'resource "snowflake_grant_account_role" "ops_to_admin"'
 )
 
-for res in "${EXPECTED_RESOURCES[@]}"; do
+for res in "${EXPECTED_RESOURCES_ISSUE1[@]}"; do
   if echo "$ALL_TF_CONTENT" | grep -qF "$res"; then
     pass "Found: $res"
   else
@@ -62,7 +61,6 @@ done
 # --- Test 3: Role hierarchy structure ---
 echo "[3] Role hierarchy assertions"
 
-# Check roles.tf exists and contains hierarchy grants
 if [ -f "$TF_DIR/roles.tf" ]; then
   if grep -q 'PAYMENTS_ADMIN_ROLE' "$TF_DIR/roles.tf" && \
      grep -q 'PAYMENTS_APP_ROLE' "$TF_DIR/roles.tf" && \
@@ -98,7 +96,7 @@ else
 fi
 
 # --- Test 5: Grants file exists with schema USAGE ---
-echo "[5] Grant assertions"
+echo "[5] Grant assertions (Issue #1)"
 
 if [ -f "$TF_DIR/grants.tf" ]; then
   if grep -q 'USAGE' "$TF_DIR/grants.tf"; then
@@ -108,6 +106,216 @@ if [ -f "$TF_DIR/grants.tf" ]; then
   fi
 else
   fail "grants.tf does not exist"
+fi
+
+# =============================================================================
+# Issue #2: Warehouses, compute pool, image repo, stages, resource monitor
+# =============================================================================
+
+echo ""
+echo "--- Issue #2: Warehouses, Compute, Stages ---"
+echo ""
+
+# --- Test 6: warehouses.tf exists with all three warehouses ---
+echo "[6] Warehouse declarations"
+
+if [ -f "$TF_DIR/warehouses.tf" ]; then
+  pass "warehouses.tf exists"
+
+  # PAYMENTS_REFRESH_WH — standard warehouse (native resource)
+  if echo "$ALL_TF_CONTENT" | grep -qF 'resource "snowflake_warehouse" "payments_refresh_wh"'; then
+    pass "Found: snowflake_warehouse.payments_refresh_wh"
+  else
+    fail "Missing: snowflake_warehouse.payments_refresh_wh"
+  fi
+
+  # PAYMENTS_ADMIN_WH — standard warehouse (native resource)
+  if echo "$ALL_TF_CONTENT" | grep -qF 'resource "snowflake_warehouse" "payments_admin_wh"'; then
+    pass "Found: snowflake_warehouse.payments_admin_wh"
+  else
+    fail "Missing: snowflake_warehouse.payments_admin_wh"
+  fi
+
+  # PAYMENTS_INTERACTIVE_WH — interactive warehouse (via snowflake_execute)
+  if echo "$ALL_TF_CONTENT" | grep -qF 'resource "snowflake_execute" "payments_interactive_wh"'; then
+    pass "Found: snowflake_execute.payments_interactive_wh"
+  else
+    fail "Missing: snowflake_execute.payments_interactive_wh"
+  fi
+
+  # Verify interactive warehouse DDL contains CREATE INTERACTIVE WAREHOUSE
+  if echo "$ALL_TF_CONTENT" | grep -qF 'CREATE INTERACTIVE WAREHOUSE'; then
+    pass "CREATE INTERACTIVE WAREHOUSE DDL present"
+  else
+    fail "CREATE INTERACTIVE WAREHOUSE DDL missing"
+  fi
+
+  # Verify auto_suspend settings
+  if grep -q 'auto_suspend.*=.*120' "$TF_DIR/warehouses.tf"; then
+    pass "PAYMENTS_REFRESH_WH auto_suspend=120"
+  else
+    fail "PAYMENTS_REFRESH_WH auto_suspend=120 not found"
+  fi
+
+  if grep -q 'auto_suspend.*=.*60' "$TF_DIR/warehouses.tf"; then
+    pass "PAYMENTS_ADMIN_WH auto_suspend=60"
+  else
+    fail "PAYMENTS_ADMIN_WH auto_suspend=60 not found"
+  fi
+
+  if grep -q 'AUTO_SUSPEND.*=.*86400\|auto_suspend.*86400' "$TF_DIR/warehouses.tf"; then
+    pass "PAYMENTS_INTERACTIVE_WH AUTO_SUSPEND=86400"
+  else
+    fail "PAYMENTS_INTERACTIVE_WH AUTO_SUSPEND=86400 not found"
+  fi
+else
+  fail "warehouses.tf does not exist"
+  fail "Missing: snowflake_warehouse.payments_refresh_wh"
+  fail "Missing: snowflake_warehouse.payments_admin_wh"
+  fail "Missing: snowflake_execute.payments_interactive_wh"
+  fail "CREATE INTERACTIVE WAREHOUSE DDL missing"
+  fail "PAYMENTS_REFRESH_WH auto_suspend=120 not found"
+  fail "PAYMENTS_ADMIN_WH auto_suspend=60 not found"
+  fail "PAYMENTS_INTERACTIVE_WH AUTO_SUSPEND=86400 not found"
+fi
+
+# --- Test 7: compute_pools.tf with PAYMENTS_DASHBOARD_POOL ---
+echo "[7] Compute pool declarations"
+
+if [ -f "$TF_DIR/compute_pools.tf" ]; then
+  pass "compute_pools.tf exists"
+
+  if echo "$ALL_TF_CONTENT" | grep -qF 'resource "snowflake_execute" "payments_dashboard_pool"'; then
+    pass "Found: snowflake_execute.payments_dashboard_pool"
+  else
+    fail "Missing: snowflake_execute.payments_dashboard_pool"
+  fi
+
+  if echo "$ALL_TF_CONTENT" | grep -qF 'CREATE COMPUTE POOL'; then
+    pass "CREATE COMPUTE POOL DDL present"
+  else
+    fail "CREATE COMPUTE POOL DDL missing"
+  fi
+
+  if grep -q 'PAYMENTS_DASHBOARD_POOL' "$TF_DIR/compute_pools.tf"; then
+    pass "PAYMENTS_DASHBOARD_POOL name present"
+  else
+    fail "PAYMENTS_DASHBOARD_POOL name missing"
+  fi
+
+  if grep -q 'CPU_X64_S' "$TF_DIR/compute_pools.tf"; then
+    pass "CPU_X64_S instance family present"
+  else
+    fail "CPU_X64_S instance family missing"
+  fi
+else
+  fail "compute_pools.tf does not exist"
+  fail "Missing: snowflake_execute.payments_dashboard_pool"
+  fail "CREATE COMPUTE POOL DDL missing"
+  fail "PAYMENTS_DASHBOARD_POOL name missing"
+  fail "CPU_X64_S instance family missing"
+fi
+
+# --- Test 8: stages.tf with image repo and spec stage ---
+echo "[8] Stage and image repository declarations"
+
+if [ -f "$TF_DIR/stages.tf" ]; then
+  pass "stages.tf exists"
+
+  # Image repository via snowflake_execute
+  if echo "$ALL_TF_CONTENT" | grep -qF 'resource "snowflake_execute" "dashboard_repo"'; then
+    pass "Found: snowflake_execute.dashboard_repo"
+  else
+    fail "Missing: snowflake_execute.dashboard_repo"
+  fi
+
+  if echo "$ALL_TF_CONTENT" | grep -q 'CREATE IMAGE REPOSITORY\|CREATE OR REPLACE IMAGE REPOSITORY'; then
+    pass "CREATE IMAGE REPOSITORY DDL present"
+  else
+    fail "CREATE IMAGE REPOSITORY DDL missing"
+  fi
+
+  if grep -q 'DASHBOARD_REPO' "$TF_DIR/stages.tf"; then
+    pass "DASHBOARD_REPO name present"
+  else
+    fail "DASHBOARD_REPO name missing"
+  fi
+
+  # Spec stage (native snowflake_stage_internal or snowflake_execute)
+  if echo "$ALL_TF_CONTENT" | grep -q 'resource "snowflake_stage_internal" "specs"\|resource "snowflake_stage" "specs"\|resource "snowflake_execute" "specs_stage"'; then
+    pass "Found: specs stage resource"
+  else
+    fail "Missing: specs stage resource"
+  fi
+
+  if grep -q 'SPECS' "$TF_DIR/stages.tf"; then
+    pass "SPECS stage name present"
+  else
+    fail "SPECS stage name missing"
+  fi
+else
+  fail "stages.tf does not exist"
+  fail "Missing: snowflake_execute.dashboard_repo"
+  fail "CREATE IMAGE REPOSITORY DDL missing"
+  fail "DASHBOARD_REPO name missing"
+  fail "Missing: specs stage resource"
+  fail "SPECS stage name missing"
+fi
+
+# --- Test 9: Warehouse USAGE grants in grants.tf ---
+echo "[9] Warehouse grants (Issue #2)"
+
+if [ -f "$TF_DIR/grants.tf" ]; then
+  # APP role should have USAGE on interactive WH
+  if grep -q 'app.*interactive\|interactive.*app\|PAYMENTS_INTERACTIVE_WH.*PAYMENTS_APP\|PAYMENTS_APP.*PAYMENTS_INTERACTIVE_WH' "$TF_DIR/grants.tf"; then
+    pass "APP role warehouse grant references interactive WH"
+  else
+    fail "APP role warehouse grant for interactive WH missing"
+  fi
+
+  # APP role should have USAGE on admin WH
+  if grep -q 'app.*admin_wh\|PAYMENTS_ADMIN_WH.*PAYMENTS_APP\|PAYMENTS_APP.*PAYMENTS_ADMIN_WH' "$TF_DIR/grants.tf"; then
+    pass "APP role warehouse grant references admin WH"
+  else
+    fail "APP role warehouse grant for admin WH missing"
+  fi
+
+  # BIND SERVICE ENDPOINT grant for APP role
+  if grep -q 'BIND SERVICE ENDPOINT' "$TF_DIR/grants.tf"; then
+    pass "BIND SERVICE ENDPOINT grant present"
+  else
+    fail "BIND SERVICE ENDPOINT grant missing"
+  fi
+else
+  fail "grants.tf does not exist"
+fi
+
+# --- Test 10: Resource monitor ---
+echo "[10] Resource monitor"
+
+if echo "$ALL_TF_CONTENT" | grep -qF 'resource "snowflake_resource_monitor"'; then
+  pass "Found: snowflake_resource_monitor resource"
+else
+  fail "Missing: snowflake_resource_monitor resource"
+fi
+
+if echo "$ALL_TF_CONTENT" | grep -q 'credit_quota'; then
+  pass "credit_quota configured"
+else
+  fail "credit_quota not configured"
+fi
+
+# --- Test 11: Updated outputs ---
+echo "[11] Output assertions (Issue #2)"
+
+if [ -f "$TF_DIR/outputs.tf" ]; then
+  if grep -q 'warehouse_names\|warehouse' "$TF_DIR/outputs.tf"; then
+    pass "Warehouse outputs present"
+  else
+    fail "Warehouse outputs missing from outputs.tf"
+  fi
+else
+  fail "outputs.tf does not exist"
 fi
 
 # --- Summary ---


### PR DESCRIPTION
## Summary
- **warehouses.tf**: Three warehouses — `PAYMENTS_INTERACTIVE_WH` (interactive type via `snowflake_execute`, AUTO_SUSPEND=86400), `PAYMENTS_REFRESH_WH` (standard, 120s), `PAYMENTS_ADMIN_WH` (standard, 60s)
- **compute_pools.tf**: `PAYMENTS_DASHBOARD_POOL` (CPU_X64_S, min=1, max=2, auto-suspend 3600s) via `snowflake_execute` — no native TF resource available
- **stages.tf**: `DASHBOARD_REPO` image repository via `snowflake_execute`, `SPECS` internal stage via `snowflake_stage_internal`
- **resource_monitor.tf**: `PAYMENTS_MONITOR` with 100 credit quota, notify at 75%/90%, suspend at 100%, immediate suspend at 110%
- **grants.tf**: Warehouse USAGE grants per role (APP → interactive + admin WH, OPS → admin WH, ADMIN → all with OPERATE), `BIND SERVICE ENDPOINT` for APP role
- **outputs.tf**: Added `warehouse_names`, `compute_pool_name`, `stage_names`, `resource_monitor_name`
- **tests**: Expanded from 21 to 46 assertions (25 new for Issue #2), all passing

## Design Decisions
- Interactive warehouses (`CREATE INTERACTIVE WAREHOUSE`) are not supported as a native Terraform resource in `snowflakedb/snowflake` v2.14 — used `snowflake_execute` with `execute`/`revert` pattern
- Compute pools similarly have no native resource — used `snowflake_execute`
- Image repositories have no native resource — used `snowflake_execute`
- Used `snowflake_stage_internal` instead of deprecated `snowflake_stage` for the SPECS stage
- INGEST role gets no warehouse (HP connector is serverless per spec)

## Test plan
- [x] `terraform validate` succeeds (no warnings)
- [x] All 46 TDD assertions pass (21 Issue #1 + 25 Issue #2)
- [x] All resource declarations verified via static grep
- [x] Auto-suspend values verified per spec
- [x] Grant mapping verified per spec Section 3.9.6

Closes #2

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)