### PR TITLE
feat(kafka): add HP connector v4.x configuration (#7)

### DIFF
--- a/kafka-connect/shared.json
+++ b/kafka-connect/shared.json
@@ -1,0 +1,27 @@
+{
+  "name": "auth-events-sink-payments",
+  "config": {
+    "connector.class": "com.snowflake.kafka.connector.SnowflakeStreamingSinkConnector",
+    "tasks.max": "24",
+    "topics": "payments.auth",
+
+    "snowflake.url.name": "${env:SNOWFLAKE_URL}",
+    "snowflake.user.name": "${env:SNOWFLAKE_USER}",
+    "snowflake.private.key": "${env:SNOWFLAKE_PRIVATE_KEY}",
+    "snowflake.database.name": "PAYMENTS_DB",
+    "snowflake.schema.name": "RAW",
+    "snowflake.role.name": "PAYMENTS_INGEST_ROLE",
+
+    "snowflake.topic2table.map": "payments.auth:AUTH_EVENTS_RAW",
+    "snowflake.metadata.topic": "true",
+    "snowflake.metadata.offsetAndPartition": "true",
+
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "false",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+
+    "errors.tolerance": "all",
+    "errors.log.enable": "true",
+    "errors.log.include.messages": "true"
+  }
+}


### PR DESCRIPTION
## Summary
- Create `kafka-connect/shared.json` with full v4.x HP connector config
- Connector class: `SnowflakeStreamingSinkConnector` (v4.x only)
- 24 tasks, topic2table mapping to `AUTH_EVENTS_RAW`, Kafka metadata columns enabled
- Private key externalized via `${env:SNOWFLAKE_PRIVATE_KEY}`
- No `snowflake.warehouse.name` (HP is serverless), no `snowflake.ingestion.method` (v4.x only)

Closes #7

## Test plan
- [x] Tests pass locally (red/green verified — 11/11 pass for issue #7)
- [x] Config validated against v4.x connector requirements
- [x] Live deployment requires Kafka Connect cluster + Snowflake (acceptance criteria 1-3 need infra)

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)