### PR TITLE
feat(generator): add scenario profiles and control API (#9)

### DIFF
--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/generator/main.py
+++ b/generator/main.py
@@ -1,0 +1,117 @@
+"""FastAPI control API for the payment event generator."""
+
+import asyncio
+import json
+import time
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from config import BOOTSTRAP_SERVERS, TOPIC, DEFAULT_RATE, DEFAULT_ENV
+from producer import create_producer, generate_event
+from scenarios import SCENARIOS, Baseline
+
+
+class ScenarioRequest(BaseModel):
+    profile: str
+    duration_sec: int = 300
+
+
+class RateRequest(BaseModel):
+    events_per_sec: int
+
+
+# --- State ---
+state = {
+    "producer": None,
+    "scenario": Baseline(),
+    "rate": DEFAULT_RATE,
+    "env": DEFAULT_ENV,
+    "start_time": None,
+    "event_count": 0,
+    "scenario_task": None,
+}
+
+
+async def producer_loop():
+    """Background task that produces events at the configured rate."""
+    producer = state["producer"]
+    while True:
+        rate = state["rate"]
+        interval = 1.0 / rate if rate > 0 else 1.0
+        event = generate_event(env=state["env"])
+        event = state["scenario"].modify_event(event)
+        producer.produce(
+            topic=TOPIC,
+            key=event["merchant_id"],
+            value=json.dumps(event).encode("utf-8"),
+        )
+        producer.poll(0)
+        state["event_count"] += 1
+        await asyncio.sleep(interval)
+
+
+async def auto_return_to_baseline(duration_sec: int):
+    """Return to baseline after duration expires."""
+    await asyncio.sleep(duration_sec)
+    state["scenario"] = Baseline()
+    state["scenario_task"] = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    state["producer"] = create_producer()
+    state["start_time"] = time.time()
+    task = asyncio.create_task(producer_loop())
+    yield
+    task.cancel()
+    if state["producer"]:
+        state["producer"].flush()
+
+
+app = FastAPI(title="Payment Event Generator", lifespan=lifespan)
+
+
+@app.get("/status")
+async def get_status():
+    uptime = time.time() - state["start_time"] if state["start_time"] else 0
+    return {
+        "scenario": state["scenario"].name,
+        "events_per_sec": state["rate"],
+        "env": state["env"],
+        "total_events": state["event_count"],
+        "uptime_sec": round(uptime, 1),
+    }
+
+
+@app.post("/scenario")
+async def set_scenario(req: ScenarioRequest):
+    if req.profile not in SCENARIOS:
+        return {"error": f"Unknown profile: {req.profile}", "available": list(SCENARIOS.keys())}
+
+    # Cancel any existing duration timer
+    if state["scenario_task"] is not None:
+        state["scenario_task"].cancel()
+
+    state["scenario"] = SCENARIOS[req.profile]()
+
+    # Auto-return to baseline after duration
+    state["scenario_task"] = asyncio.create_task(auto_return_to_baseline(req.duration_sec))
+
+    return {"profile": req.profile, "duration_sec": req.duration_sec}
+
+
+@app.delete("/scenario")
+async def clear_scenario():
+    if state["scenario_task"] is not None:
+        state["scenario_task"].cancel()
+        state["scenario_task"] = None
+    state["scenario"] = Baseline()
+    return {"profile": "baseline"}
+
+
+@app.post("/rate")
+async def set_rate(req: RateRequest):
+    state["rate"] = req.events_per_sec
+    return {"events_per_sec": req.events_per_sec}

--- a/generator/scenarios.py
+++ b/generator/scenarios.py
@@ -1,0 +1,81 @@
+"""Scenario profiles for modifying event distributions during demos."""
+
+import random
+from typing import Protocol
+
+
+class ScenarioProfile(Protocol):
+    """Interface for scenario profiles."""
+
+    def modify_event(self, event: dict, rng: random.Random) -> dict: ...
+
+
+class Baseline:
+    """Default scenario: ~95% approval, 50-150ms latency, uniform distribution."""
+
+    name = "baseline"
+
+    def __init__(self, seed: int | None = None):
+        self.rng = random.Random(seed) if seed is not None else random.Random()
+
+    def modify_event(self, event: dict, rng: random.Random | None = None) -> dict:
+        # No modifications — baseline uses default generate_event distribution
+        return event
+
+
+class IssuerOutage:
+    """BIN range 4111xx drops to 10% approval with ISSUER_UNAVAILABLE."""
+
+    name = "issuer_outage"
+
+    def __init__(self, seed: int | None = None):
+        self.rng = random.Random(seed) if seed is not None else random.Random()
+
+    def modify_event(self, event: dict, rng: random.Random | None = None) -> dict:
+        r = rng or self.rng
+        if event.get("issuer_bin", "").startswith("4111"):
+            if r.random() > 0.10:
+                event["auth_status"] = "DECLINED"
+                event["decline_code"] = "ISSUER_UNAVAILABLE"
+        return event
+
+
+class MerchantDeclineSpike:
+    """Specific merchant sees 60% decline rate with DO_NOT_HONOR."""
+
+    name = "merchant_decline_spike"
+    target_merchant_id = "M0003"  # TechBazaar
+
+    def __init__(self, seed: int | None = None):
+        self.rng = random.Random(seed) if seed is not None else random.Random()
+
+    def modify_event(self, event: dict, rng: random.Random | None = None) -> dict:
+        r = rng or self.rng
+        if event.get("merchant_id") == self.target_merchant_id:
+            if r.random() < 0.60:
+                event["auth_status"] = "DECLINED"
+                event["decline_code"] = "DO_NOT_HONOR"
+        return event
+
+
+class LatencySpike:
+    """EU region latency jumps to 800-2000ms, approval rate stays normal."""
+
+    name = "latency_spike"
+
+    def __init__(self, seed: int | None = None):
+        self.rng = random.Random(seed) if seed is not None else random.Random()
+
+    def modify_event(self, event: dict, rng: random.Random | None = None) -> dict:
+        r = rng or self.rng
+        if event.get("region") == "EU":
+            event["auth_latency_ms"] = round(r.uniform(800, 2000), 1)
+        return event
+
+
+SCENARIOS: dict[str, type] = {
+    "baseline": Baseline,
+    "issuer_outage": IssuerOutage,
+    "merchant_decline_spike": MerchantDeclineSpike,
+    "latency_spike": LatencySpike,
+}


### PR DESCRIPTION
## Summary
- `generator/scenarios.py` — 4 scenario profiles (baseline, issuer_outage, merchant_decline_spike, latency_spike) with modify_event interface and deterministic seed support
- `generator/main.py` — FastAPI control API: GET /status, POST /scenario (with duration auto-return), DELETE /scenario, POST /rate
- `generator/Dockerfile` — Python 3.11-slim with uvicorn

Closes #9

## Test plan
- [x] Tests pass locally (red/green verified — 46/46 pass)
- [x] All 4 scenarios modify event distributions correctly
- [x] Duration-based auto-return implemented
- [x] Acceptance criteria from issue verified

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)