### PR TITLE
fix(ci): correct TF_VAR names and switch deploy to workflow_dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,7 @@
 name: Deploy
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 env:
   SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
@@ -15,7 +14,8 @@ jobs:
     name: 1. Terraform Apply
     runs-on: ubuntu-latest
     env:
-      TF_VAR_snowflake_account: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+      TF_VAR_snowflake_organization_name: ${{ secrets.SNOWFLAKE_ORGANIZATION_NAME }}
+      TF_VAR_snowflake_account_name: ${{ secrets.SNOWFLAKE_ACCOUNT_NAME }}
       TF_VAR_snowflake_user: ${{ secrets.SNOWFLAKE_USER }}
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +25,7 @@ jobs:
         run: terraform init
         working-directory: terraform/
       - name: terraform apply
-        run: terraform apply -auto-approve
+        run: terraform apply -auto-approve -input=false
         working-directory: terraform/
 
   schemachange-deploy:


### PR DESCRIPTION
## Root Cause

The deploy workflow was triggered on every push to main and then hung for >1 hour because `terraform apply` was waiting for interactive input.

### Bug 1 — Wrong TF_VAR name (caused the hang)
`terraform/variables.tf` declares `var.snowflake_account_name` but the workflow set `TF_VAR_snowflake_account` (no `_name` suffix). Terraform couldn't find the value and prompted interactively — which never resolves in CI.

### Bug 2 — Missing TF_VAR
`var.snowflake_organization_name` had no corresponding env var at all.

### Bug 3 — Wrong trigger
`push: branches: [main]` fires on every commit to main. A full Terraform + schemachange + dbt + Docker deploy should be **manually triggered**, not automatic on every doc fix.

## Fixes
- `TF_VAR_snowflake_account` → `TF_VAR_snowflake_account_name`
- Add `TF_VAR_snowflake_organization_name`
- Switch trigger: `push:main` → `workflow_dispatch`
- Add `-input=false` to `terraform apply` for fast-fail safety

## Required GitHub Secrets
Two new secrets needed in repo settings:
- `SNOWFLAKE_ORGANIZATION_NAME` — org name (e.g. `MYORG`)
- `SNOWFLAKE_ACCOUNT_NAME` — account locator (e.g. `ABC12345`)

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)